### PR TITLE
Update @orbit/records dependency to latest beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "repository": "https://github.com/tchak/orbit-sql",
   "license": "MIT",
   "dependencies": {
-    "@orbit/records": "^0.17.0-beta.14",
+    "@orbit/records": "0.17.0-beta.25",
     "inflected": "^2.1.0",
     "knex": "^0.21.18",
     "objection": "^2.2.14"

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -82,7 +82,11 @@ export class Processor {
   async query(query: RecordQuery) {
     return transaction(this._db as Knex, async (trx) => {
       const data: (OrbitRecord | OrbitRecord[] | null)[] = [];
-      for (const expression of query.expressions) {
+      const expressions = Array.isArray(query.expressions)
+        ? query.expressions
+        : [query.expressions];
+
+      for (const expression of expressions) {
         data.push(await this.processQueryExpression(expression, trx));
       }
       return data;

--- a/src/sql-source.ts
+++ b/src/sql-source.ts
@@ -3,7 +3,6 @@ import { queryable, updatable, RequestOptions } from '@orbit/data';
 import {
   RecordSourceQueryOptions,
   RecordSchema,
-  RecordOperation,
   RecordSourceSettings,
   RecordQueryable,
   RecordUpdatable,
@@ -90,13 +89,14 @@ export class SQLSource extends RecordSource<
 
   async _update(transform: RecordTransform): Promise<any> {
     if (!this.transformLog.contains(transform.id)) {
-      const data = await this._processor.patch(
-        transform.operations as RecordOperation[]
-      );
+      const operations = Array.isArray(transform.operations)
+        ? transform.operations
+        : [transform.operations];
+      const data = await this._processor.patch(operations);
       await this.transformed([transform]);
       return {
         transform: [transform],
-        data: transform.operations.length === 1 ? data[0] : data,
+        data: Array.isArray(transform.operations) ? data : data[0],
       };
     }
   }
@@ -109,7 +109,7 @@ export class SQLSource extends RecordSource<
     const data = await this._processor.query(query);
     return {
       transform: [],
-      data: query.expressions.length === 1 ? data[0] : data,
+      data: Array.isArray(data) ? data[0] : data,
     };
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,33 +203,41 @@
   dependencies:
     "@octokit/openapi-types" "^5.1.0"
 
-"@orbit/core@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/core/-/core-0.17.0-beta.14.tgz#268308db98f39e3a4d29ba3948eb003cc25ef405"
-  integrity sha512-W8fvwPqjxJhSXMy2iJkjBaDGEyAO5aPoWTcSAx/WxhHEYFu45BcGpBij0j8OCryKJgSbSpBn5dfP087DZQu9QQ==
+"@orbit/core@^0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/core/-/core-0.17.0-beta.25.tgz#a166531146ba275c32109022cf6903e3f2dc06bf"
+  integrity sha512-7g26BNqbFipTUjDCIXGkBAVMI3nYihADezS0FA0vsNMMpAPsX8mgEYJYpPaXq6c9C8VUKaz0H700IRqAvP1ZmQ==
   dependencies:
-    "@orbit/utils" "^0.17.0-beta.14"
+    "@orbit/utils" "^0.17.0-beta.25"
 
-"@orbit/data@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/data/-/data-0.17.0-beta.14.tgz#910de6aac532f7c50352627f4bddd9837e1a718f"
-  integrity sha512-sTz45N7fjayrjoE4IBhEubCWhQlW/X6av0+NaYQu9JJgWLeFGb5RO1COV3wgkglIxxQZY5aZEnS75UxCDe9PaA==
+"@orbit/data@^0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/data/-/data-0.17.0-beta.25.tgz#8513b48fa587a4d9a7751685deb348f87bab107b"
+  integrity sha512-eDzZGSn2ocUIuR8N2LTzEgBnVQ1MlHiB8/ZpFoCyL8Acy8ALSAaOx5J5gylDooiSA/+100XtOHhquDgINKFv2g==
   dependencies:
-    "@orbit/core" "^0.17.0-beta.14"
-    "@orbit/utils" "^0.17.0-beta.14"
+    "@orbit/core" "^0.17.0-beta.25"
+    "@orbit/utils" "^0.17.0-beta.25"
 
-"@orbit/records@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/records/-/records-0.17.0-beta.14.tgz#c38b915fbf1dc5b1f7f968452a7898a4e7f7e240"
-  integrity sha512-Em40SoLdIxwM3wlwz3pif7zfBzFS+HSe1iRqGoQw0kAq3Qlp53bRU4svUT0pIyd/psQnr1FcQJ2ONjYjyll8SQ==
+"@orbit/records@0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/records/-/records-0.17.0-beta.25.tgz#46d41b688499d959422926ee0c66ec7e515e0938"
+  integrity sha512-Eg9YzvOuWnbNeK69WvSw3huoTFt+7DkDuwsTBeTi4bLjyo+NHbOHmZPHwS7U+VsXjAUtMWA0LCGRKdU836UjDg==
   dependencies:
-    "@orbit/data" "^0.17.0-beta.14"
-    "@orbit/utils" "^0.17.0-beta.14"
+    "@orbit/data" "^0.17.0-beta.25"
+    "@orbit/utils" "^0.17.0-beta.25"
+    "@orbit/validators" "^0.17.0-beta.25"
 
-"@orbit/utils@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/utils/-/utils-0.17.0-beta.14.tgz#b9b8dec255cee355e82b21e754e8e2c3bb1e2287"
-  integrity sha512-1eGvrGKJjXtgBWJ2nQe83nkIk6Kv4QvataoPoc+waRjLdoBIAgIpX7XnVTJ3XMCQO0yDxHQ7wOTpfvtnYwma0A==
+"@orbit/utils@^0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/utils/-/utils-0.17.0-beta.25.tgz#95c34c58f732a42addbcb7271213896cb3b29a25"
+  integrity sha512-7YdfdHlQr+838ikOlu053/dG+8wrn5Ddw/E/7+YCT3UuNtonWy69e3omZkuFsHEf+6zNDV8FouxfOS9txCXFcg==
+
+"@orbit/validators@^0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/validators/-/validators-0.17.0-beta.25.tgz#54a7d8a591e6128ba3a13e7cf44f5907ea6986b4"
+  integrity sha512-eB0OIC8gIoeoBDgjKRqW9nji+SNgGA0sD0fr0lQuGmmWmTax4+GQuciXhibiWuh4sBxzQzxfNMrCfOos4h2MSw==
+  dependencies:
+    "@orbit/utils" "^0.17.0-beta.25"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"


### PR DESCRIPTION
0.17.0-beta.19 introduced [breaking changes](https://github.com/orbitjs/orbit/releases/tag/v0.17.0-beta.19
), this updates to handle that `Query.expressions` can be `RecordQueryExpression | RecordQueryExpression[]`. Without it, I was getting `query.expressions is not iterable` errors. I chose to make the dependency exact instead of `^` because there could be further breaking changes in the 0.17 cycle and I struggled to get `resolutions` and/or `nohoist` working to override it for just the project that was consuming this in a monorepo.

This has Typescript failure in `sql-source-legacy-test.ts` that I commented out; I’m not sure how important it is given the file name, but if you have a suggestion about how it could be fixed, let me know!

> Property 'recordInitializer' does not exist on type 'RecordTransformBuilder<string, RecordIdentity, UninitializedRecord>'

Thanks for your work on this (and `koa-orbit`, which I may need to make a parallel PR for), it’s helped me get started with an Orbit project more easily.